### PR TITLE
Remove android dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ script:
    
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
-language: android
-jdk:
-    - oraclejdk8
-android:
-  components:
-    - platform-tools
-    - build-tools-23.0.1
-    - android-23
-    - extra-android-m2repository
-    - extra-google-m2repository
+language: java
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 script:
    - cd options

--- a/options/build.gradle
+++ b/options/build.gradle
@@ -1,17 +1,6 @@
-def getLocalRepository() {
-    String androidHome = System.getenv().get("ANDROID_HOME")
-    if (androidHome == null) {
-        throw new StopActionException("System env does not contain ANDROID_HOME. " +
-                "Set it to point to your Android SDK.")
-    }
-    return androidHome + "/extras/android/m2repository"
-}
-
 allprojects {
     repositories {
         jcenter()
-
-        maven { url getLocalRepository() }
     }
 }
 

--- a/options/core/build.gradle
+++ b/options/core/build.gradle
@@ -35,6 +35,7 @@ sourceSets {
     test.java.srcDirs += 'src/test/kotlin'
 }
 
+
 afterEvaluate {
     sourceSets.all { sourceSet ->
         if (!sourceSet.name.startsWith("test")) {

--- a/options/core/build.gradle
+++ b/options/core/build.gradle
@@ -35,7 +35,6 @@ sourceSets {
     test.java.srcDirs += 'src/test/kotlin'
 }
 
-
 afterEvaluate {
     sourceSets.all { sourceSet ->
         if (!sourceSet.name.startsWith("test")) {

--- a/options/core/build.gradle
+++ b/options/core/build.gradle
@@ -37,8 +37,7 @@ sourceSets {
 
 afterEvaluate {
     sourceSets.all { sourceSet ->
-        if (!sourceSet.name.startsWith("test"))
-        {
+        if (!sourceSet.name.startsWith("test")) {
             sourceSet.kotlin.setSrcDirs([])
         }
     }
@@ -46,8 +45,8 @@ afterEvaluate {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:support-annotations:23.4.0'
     compile project(':functions')
+    compile 'org.jetbrains:annotations:15.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile "org.jetbrains.kotlin:kotlin-stdlib:1.0.1-2"

--- a/options/core/src/main/java/polanski/option/AtomicOption.java
+++ b/options/core/src/main/java/polanski/option/AtomicOption.java
@@ -1,7 +1,7 @@
 package polanski.option;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,7 +36,7 @@ public final class AtomicOption<T> extends AtomicReference<Option<T>> {
      *
      * @return the previous value
      */
-    @NonNull
+    @NotNull
     public Option<T> getAndClear() {
         return getAndSet(Option.<T>none());
     }

--- a/options/core/src/main/java/polanski/option/None.java
+++ b/options/core/src/main/java/polanski/option/None.java
@@ -1,7 +1,7 @@
 package polanski.option;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -35,106 +35,106 @@ public final class None<T> extends Option<T> {
     }
 
     @Override
-    public Option<T> ifSome(@NonNull final Action1<T> action) {
+    public Option<T> ifSome(@NotNull final Action1<T> action) {
         // Do nothing
         return this;
     }
 
     @Override
-    public Option<T> ifNone(@NonNull final Action0 action) {
+    public Option<T> ifNone(@NotNull final Action0 action) {
         action.call();
         return this;
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> Option<OUT> map(@NonNull final Func1<T, OUT> f) {
+    public <OUT> Option<OUT> map(@NotNull final Func1<T, OUT> f) {
         return none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> Option<OUT> flatMap(@NonNull final Func1<T, Option<OUT>> f) {
+    public <OUT> Option<OUT> flatMap(@NotNull final Func1<T, Option<OUT>> f) {
         return none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public Option<T> filter(@NonNull final Func1<T, Boolean> predicate) {
+    public Option<T> filter(@NotNull final Func1<T, Boolean> predicate) {
         return none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public Option<T> orOption(@NonNull final Func0<Option<T>> f) {
+    public Option<T> orOption(@NotNull final Func0<Option<T>> f) {
         return f.call();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public T orDefault(@NonNull final Func0<T> def) {
+    public T orDefault(@NotNull final Func0<T> def) {
         return def.call();
     }
 
-    @NonNull
+    @NotNull
     @Override
     T getUnsafe() {
         throw new IllegalStateException();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> Option<OUT> ofType(@NonNull Class<OUT> type) {
+    public <OUT> Option<OUT> ofType(@NotNull Class<OUT> type) {
         return none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> OUT match(@NonNull Func1<T, OUT> fSome,
-                           @NonNull Func0<OUT> fNone) {
+    public <OUT> OUT match(@NotNull Func1<T, OUT> fSome,
+                           @NotNull Func0<OUT> fNone) {
         return fNone.call();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public polanski.option.Unit matchAction(@NonNull Action1<T> fSome, @NonNull Action0 fNone) {
+    public polanski.option.Unit matchAction(@NotNull Action1<T> fSome, @NotNull Action0 fNone) {
         return polanski.option.Unit.from(fNone);
     }
 
     @Nullable
     @Override
-    public <OUT> OUT matchUnsafe(@NonNull Func1<T, OUT> fSome, @NonNull Func0<OUT> fNone) {
+    public <OUT> OUT matchUnsafe(@NotNull Func1<T, OUT> fSome, @NotNull Func0<OUT> fNone) {
         return fNone.call();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN, OUT> Option<OUT> lift(@NonNull final Option<IN> optionB,
-                                      @NonNull final Func2<T, IN, OUT> f) {
+    public <IN, OUT> Option<OUT> lift(@NotNull final Option<IN> optionB,
+                                      @NotNull final Func2<T, IN, OUT> f) {
         return none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN1, IN2, OUT> Option<OUT> lift(@NonNull Option<IN1> option1,
-                                            @NonNull Option<IN2> option2,
-                                            @NonNull Func3<T, IN1, IN2, OUT> f) {
+    public <IN1, IN2, OUT> Option<OUT> lift(@NotNull Option<IN1> option1,
+                                            @NotNull Option<IN2> option2,
+                                            @NotNull Func3<T, IN1, IN2, OUT> f) {
         return none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN1, IN2, IN3, OUT> Option<OUT> lift(@NonNull Option<IN1> option1,
-                                                 @NonNull Option<IN2> option2,
-                                                 @NonNull Option<IN3> option3,
-                                                 @NonNull Func4<T, IN1, IN2, IN3, OUT> f) {
+    public <IN1, IN2, IN3, OUT> Option<OUT> lift(@NotNull Option<IN1> option1,
+                                                 @NotNull Option<IN2> option2,
+                                                 @NotNull Option<IN3> option3,
+                                                 @NotNull Func4<T, IN1, IN2, IN3, OUT> f) {
         return none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN, OUT> Option<OUT> lift(@NonNull final List<Option<IN>> options,
-                                      @NonNull final FuncN<OUT> f) {
+    public <IN, OUT> Option<OUT> lift(@NotNull final List<Option<IN>> options,
+                                      @NotNull final FuncN<OUT> f) {
         return none();
     }
 

--- a/options/core/src/main/java/polanski/option/Option.java
+++ b/options/core/src/main/java/polanski/option/Option.java
@@ -1,7 +1,7 @@
 package polanski.option;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -25,7 +25,7 @@ public abstract class Option<T> {
     /**
      * Representation of non existing value
      */
-    @NonNull
+    @NotNull
     public static final None NONE = new None();
 
     /**
@@ -35,7 +35,7 @@ public abstract class Option<T> {
      * @return NONE
      */
     @SuppressWarnings("unchecked")
-    @NonNull
+    @NotNull
     public static <T> Option<T> none() {
         return NONE;
     }
@@ -60,7 +60,7 @@ public abstract class Option<T> {
      * @param action Action that is called on the inner value
      * @return this {@link Option}
      */
-    public abstract Option<T> ifSome(@NonNull final Action1<T> action);
+    public abstract Option<T> ifSome(@NotNull final Action1<T> action);
 
     /**
      * Runs the action on Option value if does not exist, otherwise does nothing
@@ -68,7 +68,7 @@ public abstract class Option<T> {
      * @param action Action that is called
      * @return this {@link Option}
      */
-    public abstract Option<T> ifNone(@NonNull final Action0 action);
+    public abstract Option<T> ifNone(@NotNull final Action0 action);
 
     /**
      * Converts inner value with @selector if value exists, otherwise does nothing
@@ -77,8 +77,8 @@ public abstract class Option<T> {
      * @param <OUT>    Result type
      * @return If value exists, returns converted value otherwise does nothing
      */
-    @NonNull
-    public abstract <OUT> Option<OUT> map(@NonNull final Func1<T, OUT> selector);
+    @NotNull
+    public abstract <OUT> Option<OUT> map(@NotNull final Func1<T, OUT> selector);
 
     /**
      * Binds option to another option
@@ -87,8 +87,8 @@ public abstract class Option<T> {
      * @param <OUT>    Result type
      * @return Bound option
      */
-    @NonNull
-    public abstract <OUT> Option<OUT> flatMap(@NonNull final Func1<T, Option<OUT>> selector);
+    @NotNull
+    public abstract <OUT> Option<OUT> flatMap(@NotNull final Func1<T, Option<OUT>> selector);
 
     /**
      * Filters options fulfilling given @predicate
@@ -96,8 +96,8 @@ public abstract class Option<T> {
      * @param predicate Function returning true if the parameter should be included
      * @return Some if the value checks the condition, otherwise None
      */
-    @NonNull
-    public abstract Option<T> filter(@NonNull final Func1<T, Boolean> predicate);
+    @NotNull
+    public abstract Option<T> filter(@NotNull final Func1<T, Boolean> predicate);
 
     /**
      * Returns option if current value is None
@@ -105,8 +105,8 @@ public abstract class Option<T> {
      * @param f Function returning new Option
      * @return Option given by the function if current is None, otherwise returns current one
      */
-    @NonNull
-    public abstract Option<T> orOption(@NonNull final Func0<Option<T>> f);
+    @NotNull
+    public abstract Option<T> orOption(@NotNull final Func0<Option<T>> f);
 
     /**
      * Returns current inner value if it exists, otherwise the value supplied by @def
@@ -114,8 +114,8 @@ public abstract class Option<T> {
      * @param def Function that returns default value
      * @return If value exists, then returns it, otherwise the default
      */
-    @NonNull
-    public abstract T orDefault(@NonNull final Func0<T> def);
+    @NotNull
+    public abstract T orDefault(@NotNull final Func0<T> def);
 
     /**
      * Forcefully tries to unwrap the inner value.
@@ -125,7 +125,7 @@ public abstract class Option<T> {
      *
      * @return Value if exists, otherwise throws exception that shouldn't be caught
      */
-    @NonNull
+    @NotNull
     abstract T getUnsafe();
 
     /**
@@ -135,8 +135,8 @@ public abstract class Option<T> {
      * @param <OUT> Type the value should be cast to
      * @return Option of inner value cast to the OUT, if not possible, then None
      */
-    @NonNull
-    public abstract <OUT> Option<OUT> ofType(@NonNull final Class<OUT> type);
+    @NotNull
+    public abstract <OUT> Option<OUT> ofType(@NotNull final Class<OUT> type);
 
     /**
      * Option created from given @value
@@ -146,7 +146,7 @@ public abstract class Option<T> {
      * @return Some of the @value if it is not null, otherwise None
      */
     @SuppressWarnings("unchecked")
-    @NonNull
+    @NotNull
     public static <IN> Option<IN> ofObj(@Nullable final IN value) {
         return value == null ? Option.NONE : new Some(value);
     }
@@ -158,8 +158,8 @@ public abstract class Option<T> {
      * @param <OUT> Result type
      * @return Option of a value returned by @f, if @f threw an exception, then returns None
      */
-    @NonNull
-    public static <OUT> Option<OUT> tryAsOption(@NonNull final Func0<OUT> f) {
+    @NotNull
+    public static <OUT> Option<OUT> tryAsOption(@NotNull final Func0<OUT> f) {
         try {
             return Option.ofObj(f.call());
         } catch (Exception e) {
@@ -175,9 +175,9 @@ public abstract class Option<T> {
      * @param <OUT> Result type
      * @return Value returned by either @fSome of @fNone
      */
-    @NonNull
-    public abstract <OUT> OUT match(@NonNull final Func1<T, OUT> fSome,
-                                    @NonNull final Func0<OUT> fNone);
+    @NotNull
+    public abstract <OUT> OUT match(@NotNull final Func1<T, OUT> fSome,
+                                    @NotNull final Func0<OUT> fNone);
 
     /**
      * Matches current option to Some or None and returns unit
@@ -186,9 +186,9 @@ public abstract class Option<T> {
      * @param fNone Action that will be called if value does not exist
      * @return Unit
      */
-    @NonNull
-    public abstract Unit matchAction(@NonNull final Action1<T> fSome,
-                                     @NonNull final Action0 fNone);
+    @NotNull
+    public abstract Unit matchAction(@NotNull final Action1<T> fSome,
+                                     @NotNull final Action0 fNone);
 
     /**
      * Matches current optional to Some orResult None and returns appropriate value
@@ -199,15 +199,15 @@ public abstract class Option<T> {
      * @return Value returned by either @fSome of @fNone
      */
     @Nullable
-    public abstract <OUT> OUT matchUnsafe(@NonNull final Func1<T, OUT> fSome,
-                                          @NonNull final Func0<OUT> fNone);
+    public abstract <OUT> OUT matchUnsafe(@NotNull final Func1<T, OUT> fSome,
+                                          @NotNull final Func0<OUT> fNone);
 
     /**
      * Identity function
      *
      * @return Current option
      */
-    @NonNull
+    @NotNull
     public Option<T> id() {
         return this;
     }
@@ -221,9 +221,9 @@ public abstract class Option<T> {
      * @param <OUT>   Result type
      * @return Option of some if all the Options were Some, otherwise None
      */
-    @NonNull
-    public abstract <IN1, OUT> Option<OUT> lift(@NonNull final Option<IN1> option1,
-                                                @NonNull final Func2<T, IN1, OUT> f);
+    @NotNull
+    public abstract <IN1, OUT> Option<OUT> lift(@NotNull final Option<IN1> option1,
+                                                @NotNull final Func2<T, IN1, OUT> f);
 
     /**
      * Combines given Options using @f
@@ -236,10 +236,10 @@ public abstract class Option<T> {
      * @param <OUT>   Result type
      * @return Option of some if all the Options were Some, otherwise None
      */
-    @NonNull
-    public abstract <IN1, IN2, OUT> Option<OUT> lift(@NonNull final Option<IN1> option1,
-                                                     @NonNull final Option<IN2> option2,
-                                                     @NonNull final Func3<T, IN1, IN2, OUT> f);
+    @NotNull
+    public abstract <IN1, IN2, OUT> Option<OUT> lift(@NotNull final Option<IN1> option1,
+                                                     @NotNull final Option<IN2> option2,
+                                                     @NotNull final Func3<T, IN1, IN2, OUT> f);
 
     /**
      * Combines given Options using @f
@@ -254,11 +254,11 @@ public abstract class Option<T> {
      * @param <OUT>   Result type
      * @return Option of some if all the Options were Some, otherwise None
      */
-    @NonNull
-    public abstract <IN1, IN2, IN3, OUT> Option<OUT> lift(@NonNull final Option<IN1> option1,
-                                                          @NonNull final Option<IN2> option2,
-                                                          @NonNull final Option<IN3> option3,
-                                                          @NonNull final Func4<T, IN1, IN2, IN3, OUT> f);
+    @NotNull
+    public abstract <IN1, IN2, IN3, OUT> Option<OUT> lift(@NotNull final Option<IN1> option1,
+                                                          @NotNull final Option<IN2> option2,
+                                                          @NotNull final Option<IN3> option3,
+                                                          @NotNull final Func4<T, IN1, IN2, IN3, OUT> f);
 
     /**
      * Combines given Options using @f.
@@ -269,10 +269,10 @@ public abstract class Option<T> {
      * @param <OUT>   Result type
      * @return Option of some if all the Options were Some, otherwise None
      */
-    @NonNull
+    @NotNull
     public abstract <IN, OUT> Option<OUT> lift(
-            @NonNull final List<Option<IN>> options,
-            @NonNull final FuncN<OUT> f);
+            @NotNull final List<Option<IN>> options,
+            @NotNull final FuncN<OUT> f);
 
     /**
      * Logs the value of the Option via given logging function.
@@ -280,8 +280,8 @@ public abstract class Option<T> {
      * @param logging Logging function
      * @return Unchanged option
      */
-    @NonNull
-    public Option<T> log(@NonNull final Action1<String> logging) {
+    @NotNull
+    public Option<T> log(@NotNull final Action1<String> logging) {
         return log("", logging);
     }
 
@@ -292,12 +292,12 @@ public abstract class Option<T> {
      * @param logging Logging function
      * @return Unchanged option
      */
-    @NonNull
-    public Option<T> log(@NonNull String tag,
-                         @NonNull final Action1<String> logging) {
+    @NotNull
+    public Option<T> log(@NotNull String tag,
+                         @NotNull final Action1<String> logging) {
         logging.call(tag.isEmpty()
-                             ? this.toString()
-                             : String.format("%s: %s", tag, this));
+                ? this.toString()
+                : String.format("%s: %s", tag, this));
         return this;
     }
 

--- a/options/core/src/main/java/polanski/option/Option.java
+++ b/options/core/src/main/java/polanski/option/Option.java
@@ -306,7 +306,7 @@ public abstract class Option<T> {
      *
      * @return the new {@link OptionAssertion} instance.
      */
-    @NonNull
+    @NotNull
     public OptionAssertion<T> test() {
         return new OptionAssertion<>(this);
     }

--- a/options/core/src/main/java/polanski/option/OptionAssertion.java
+++ b/options/core/src/main/java/polanski/option/OptionAssertion.java
@@ -1,10 +1,9 @@
 package polanski.option;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
 import java.util.Objects;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import polanski.option.function.Func1;
 
 /**
@@ -12,10 +11,10 @@ import polanski.option.function.Func1;
  */
 public final class OptionAssertion<T> {
 
-    @NonNull
+    @NotNull
     private final Option<T> actual;
 
-    OptionAssertion(@NonNull final Option<T> actual) {
+    OptionAssertion(@NotNull final Option<T> actual) {
         checkNotNull(actual, "Option cannot be null");
 
         this.actual = actual;
@@ -35,7 +34,7 @@ public final class OptionAssertion<T> {
      *
      * @return this.
      */
-    @NonNull
+    @NotNull
     public OptionAssertion<T> assertIsSome() {
         if (!actual.isSome()) {
             throw fail("Option was not Some");
@@ -50,8 +49,8 @@ public final class OptionAssertion<T> {
      * @param expected The expected value. May not be null.
      * @return this.
      */
-    @NonNull
-    public OptionAssertion<T> assertValue(@NonNull final T expected) {
+    @NotNull
+    public OptionAssertion<T> assertValue(@NotNull final T expected) {
         checkNotNull(expected, "Expected value cannot be null: use assertNone instead");
 
         if (!actual.isSome()) {
@@ -73,8 +72,8 @@ public final class OptionAssertion<T> {
      * @param predicate The predicate function. May not be null.
      * @return this.
      */
-    @NonNull
-    public OptionAssertion<T> assertValue(@NonNull final Func1<T, Boolean> predicate) {
+    @NotNull
+    public OptionAssertion<T> assertValue(@NotNull final Func1<T, Boolean> predicate) {
         checkNotNull(predicate, "Predicate function cannot be null");
 
         if (!actual.isSome()) {
@@ -87,8 +86,8 @@ public final class OptionAssertion<T> {
         return this;
     }
 
-    @NonNull
-    private static <T> Func1<T, Boolean> equalsPredicate(@NonNull final T expected) {
+    @NotNull
+    private static <T> Func1<T, Boolean> equalsPredicate(@NotNull final T expected) {
         return new Func1<T, Boolean>() {
             @Override
             public Boolean call(final T t) {
@@ -97,12 +96,12 @@ public final class OptionAssertion<T> {
         };
     }
 
-    private static <T> boolean matches(@NonNull final Option<T> actual,
-                                       @NonNull final Func1<T, Boolean> predicate) {
+    private static <T> boolean matches(@NotNull final Option<T> actual,
+                                       @NotNull final Func1<T, Boolean> predicate) {
         return actual.filter(predicate).isSome();
     }
 
-    @NonNull
+    @NotNull
     private AssertionError fail(@Nullable final String message) {
         StringBuilder b = new StringBuilder();
         b.append(message);
@@ -115,7 +114,7 @@ public final class OptionAssertion<T> {
     }
 
     private static <T> void checkNotNull(@Nullable final T value,
-                                         @NonNull final String msg) {
+                                         @NotNull final String msg) {
         if (value == null) {
             throw new IllegalArgumentException(msg);
         }

--- a/options/core/src/main/java/polanski/option/OptionUnsafe.java
+++ b/options/core/src/main/java/polanski/option/OptionUnsafe.java
@@ -1,6 +1,6 @@
 package polanski.option;
 
-import android.support.annotation.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Helper class allowing unsafe operations on Option
@@ -13,21 +13,21 @@ public final class OptionUnsafe {
 
     /**
      * ATTENTION: Only use it when you know what you are doing!
-     *
+     * <p>
      * Returns inner value of option if it is Some, otherwise will throw uncatchable exception
      *
      * @param option Option that will be unwrapped
      * @param <T>    Wrapped type
      * @return Value of Some orResult if None, throws exception
      */
-    @NonNull
-    public static <T> T getUnsafe(@NonNull final Option<T> option) {
+    @NotNull
+    public static <T> T getUnsafe(@NotNull final Option<T> option) {
         return option.getUnsafe();
     }
 
     /**
      * ATTENTION: Only use it when you know what you are doing!
-     *
+     * <p>
      * Returns inner value of option if it is Some, otherwise will throw give RuntimeException
      *
      * @param option    Option that will be unwrapped
@@ -35,9 +35,9 @@ public final class OptionUnsafe {
      * @param <T>       Wrapped type
      * @return Value of Some orResult if None, throws exception
      */
-    @NonNull
-    public static <T> T orThrowUnsafe(@NonNull final Option<T> option,
-                                      @NonNull final RuntimeException exception) {
+    @NotNull
+    public static <T> T orThrowUnsafe(@NotNull final Option<T> option,
+                                      @NotNull final RuntimeException exception) {
         if (option.isSome()) {
             return option.getUnsafe();
         } else {

--- a/options/core/src/main/java/polanski/option/OptionUnsafe.java
+++ b/options/core/src/main/java/polanski/option/OptionUnsafe.java
@@ -13,7 +13,7 @@ public final class OptionUnsafe {
 
     /**
      * ATTENTION: Only use it when you know what you are doing!
-     * <p>
+     *
      * Returns inner value of option if it is Some, otherwise will throw uncatchable exception
      *
      * @param option Option that will be unwrapped
@@ -27,7 +27,7 @@ public final class OptionUnsafe {
 
     /**
      * ATTENTION: Only use it when you know what you are doing!
-     * <p>
+     *
      * Returns inner value of option if it is Some, otherwise will throw give RuntimeException
      *
      * @param option    Option that will be unwrapped

--- a/options/core/src/main/java/polanski/option/Some.java
+++ b/options/core/src/main/java/polanski/option/Some.java
@@ -1,7 +1,7 @@
 package polanski.option;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -23,10 +23,10 @@ import static polanski.option.Unit.from;
  */
 public final class Some<T> extends Option<T> {
 
-    @NonNull
+    @NotNull
     private final T mValue;
 
-    Some(@NonNull final T value) {
+    Some(@NotNull final T value) {
         mValue = value;
     }
 
@@ -41,70 +41,70 @@ public final class Some<T> extends Option<T> {
     }
 
     @Override
-    public Option<T> ifSome(@NonNull final Action1<T> action) {
+    public Option<T> ifSome(@NotNull final Action1<T> action) {
         action.call(mValue);
         return this;
     }
 
     @Override
-    public Option<T> ifNone(@NonNull final Action0 action) {
+    public Option<T> ifNone(@NotNull final Action0 action) {
         // Do nothing
         return this;
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> Option<OUT> map(@NonNull final Func1<T, OUT> f) {
+    public <OUT> Option<OUT> map(@NotNull final Func1<T, OUT> f) {
         return ofObj(f.call(mValue));
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> Option<OUT> flatMap(@NonNull final Func1<T, Option<OUT>> f) {
+    public <OUT> Option<OUT> flatMap(@NotNull final Func1<T, Option<OUT>> f) {
         return f.call(mValue);
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public Option<T> filter(@NonNull final Func1<T, Boolean> predicate) {
+    public Option<T> filter(@NotNull final Func1<T, Boolean> predicate) {
         return predicate.call(mValue) ? this : Option.<T>none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public Option<T> orOption(@NonNull final Func0<Option<T>> f) {
+    public Option<T> orOption(@NotNull final Func0<Option<T>> f) {
         return this;
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public T orDefault(@NonNull final Func0<T> def) {
+    public T orDefault(@NotNull final Func0<T> def) {
         return mValue;
     }
 
-    @NonNull
+    @NotNull
     @Override
     T getUnsafe() {
         return mValue;
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> Option<OUT> ofType(@NonNull final Class<OUT> type) {
+    public <OUT> Option<OUT> ofType(@NotNull final Class<OUT> type) {
         return type.isInstance(mValue) ? ofObj(type.cast(mValue)) : Option.<OUT>none();
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <OUT> OUT match(@NonNull final Func1<T, OUT> fSome,
-                           @NonNull final Func0<OUT> fNone) {
+    public <OUT> OUT match(@NotNull final Func1<T, OUT> fSome,
+                           @NotNull final Func0<OUT> fNone) {
         return fSome.call(mValue);
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public polanski.option.Unit matchAction(@NonNull final Action1<T> fSome,
-                                            @NonNull final Action0 fNone) {
+    public polanski.option.Unit matchAction(@NotNull final Action1<T> fSome,
+                                            @NotNull final Action0 fNone) {
         return from(new Action0() {
             @Override
             public void call() {
@@ -115,14 +115,14 @@ public final class Some<T> extends Option<T> {
 
     @Nullable
     @Override
-    public <OUT> OUT matchUnsafe(@NonNull Func1<T, OUT> fSome, @NonNull Func0<OUT> fNone) {
+    public <OUT> OUT matchUnsafe(@NotNull Func1<T, OUT> fSome, @NotNull Func0<OUT> fNone) {
         return fSome.call(mValue);
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN, OUT2> Option<OUT2> lift(@NonNull final Option<IN> option,
-                                        @NonNull final Func2<T, IN, OUT2> f) {
+    public <IN, OUT2> Option<OUT2> lift(@NotNull final Option<IN> option,
+                                        @NotNull final Func2<T, IN, OUT2> f) {
         return option.map(new Func1<IN, OUT2>() {
             @Override
             public OUT2 call(final IN b) {
@@ -131,11 +131,11 @@ public final class Some<T> extends Option<T> {
         });
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN1, IN2, OUT> Option<OUT> lift(@NonNull final Option<IN1> option1,
-                                            @NonNull final Option<IN2> option2,
-                                            @NonNull final Func3<T, IN1, IN2, OUT> f) {
+    public <IN1, IN2, OUT> Option<OUT> lift(@NotNull final Option<IN1> option1,
+                                            @NotNull final Option<IN2> option2,
+                                            @NotNull final Func3<T, IN1, IN2, OUT> f) {
         return option1.lift(option2, new Func2<IN1, IN2, OUT>() {
             @Override
             public OUT call(final IN1 o1, final IN2 o2) {
@@ -144,12 +144,12 @@ public final class Some<T> extends Option<T> {
         });
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN1, IN2, IN3, OUT> Option<OUT> lift(@NonNull final Option<IN1> option1,
-                                                 @NonNull final Option<IN2> option2,
-                                                 @NonNull final Option<IN3> option3,
-                                                 @NonNull final Func4<T, IN1, IN2, IN3, OUT> f) {
+    public <IN1, IN2, IN3, OUT> Option<OUT> lift(@NotNull final Option<IN1> option1,
+                                                 @NotNull final Option<IN2> option2,
+                                                 @NotNull final Option<IN3> option3,
+                                                 @NotNull final Func4<T, IN1, IN2, IN3, OUT> f) {
         return option1.lift(option2, option3, new Func3<IN1, IN2, IN3, OUT>() {
             @Override
             public OUT call(final IN1 o1, final IN2 o2, final IN3 o3) {
@@ -158,10 +158,10 @@ public final class Some<T> extends Option<T> {
         });
     }
 
-    @NonNull
+    @NotNull
     @Override
-    public <IN, OUT> Option<OUT> lift(@NonNull final List<Option<IN>> options,
-                                      @NonNull final FuncN<OUT> f) {
+    public <IN, OUT> Option<OUT> lift(@NotNull final List<Option<IN>> options,
+                                      @NotNull final FuncN<OUT> f) {
 
         return options.size() == 1
                 ? first(options).map(new Func1<IN, OUT>() {
@@ -171,25 +171,25 @@ public final class Some<T> extends Option<T> {
             }
         })
                 : first(options).lift(tail(options), new FuncN<OUT>() {
-                    @Override
-                    public OUT call(final Object... list) {
-                        return f.call(combine(mValue, list));
-                    }
-                });
+            @Override
+            public OUT call(final Object... list) {
+                return f.call(combine(mValue, list));
+            }
+        });
     }
 
-    @NonNull
-    private static <T> T first(@NonNull final List<T> options) {
+    @NotNull
+    private static <T> T first(@NotNull final List<T> options) {
         return options.get(0);
     }
 
-    @NonNull
-    private static <T> List<T> tail(@NonNull final List<T> options) {
+    @NotNull
+    private static <T> List<T> tail(@NotNull final List<T> options) {
         return options.subList(1, options.size());
     }
 
-    @NonNull
-    private static Object[] combine(@NonNull final Object[] a, @NonNull final Object[] b) {
+    @NotNull
+    private static Object[] combine(@NotNull final Object[] a, @NotNull final Object[] b) {
         final int length = a.length + b.length;
         Object[] result = new Object[length];
         System.arraycopy(a, 0, result, 0, a.length);
@@ -197,8 +197,8 @@ public final class Some<T> extends Option<T> {
         return result;
     }
 
-    @NonNull
-    private static Object[] combine(@NonNull final Object a, @NonNull final Object[] b) {
+    @NotNull
+    private static Object[] combine(@NotNull final Object a, @NotNull final Object[] b) {
         return combine(new Object[]{a}, b);
     }
 
@@ -211,13 +211,13 @@ public final class Some<T> extends Option<T> {
     @Override
     public boolean equals(final Object o) {
         return ofObj(o)
-                       .ofType(Some.class)
-                       .filter(new Func1<Some, Boolean>() {
-                           @Override
-                           public Boolean call(final Some some) {
-                               return some.getUnsafe().equals(mValue);
-                           }
-                       }) != NONE;
+                .ofType(Some.class)
+                .filter(new Func1<Some, Boolean>() {
+                    @Override
+                    public Boolean call(final Some some) {
+                        return some.getUnsafe().equals(mValue);
+                    }
+                }) != NONE;
     }
 
     @Override

--- a/options/core/src/main/java/polanski/option/Some.java
+++ b/options/core/src/main/java/polanski/option/Some.java
@@ -170,12 +170,13 @@ public final class Some<T> extends Option<T> {
                 return f.call(it, mValue);
             }
         })
-                : first(options).lift(tail(options), new FuncN<OUT>() {
-            @Override
-            public OUT call(final Object... list) {
-                return f.call(combine(mValue, list));
-            }
-        });
+                : first(options).lift(tail(options),
+                new FuncN<OUT>() {
+                    @Override
+                    public OUT call(final Object... list) {
+                        return f.call(combine(mValue, list));
+                    }
+                });
     }
 
     @NotNull

--- a/options/core/src/main/java/polanski/option/Unit.java
+++ b/options/core/src/main/java/polanski/option/Unit.java
@@ -1,7 +1,7 @@
 package polanski.option;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import polanski.option.function.Action0;
 
@@ -22,8 +22,8 @@ public enum Unit {
      * @param action to be executed
      * @return Unit
      */
-    @NonNull
-    public static Unit from(@NonNull final Action0 action) {
+    @NotNull
+    public static Unit from(@NotNull final Action0 action) {
         action.call();
         return DEFAULT;
     }
@@ -34,7 +34,7 @@ public enum Unit {
      * @param ignored to be ignored
      * @return Unit
      */
-    @NonNull
+    @NotNull
     public static Unit asUnit(@Nullable final Object ignored) {
         return DEFAULT;
     }


### PR DESCRIPTION
The Android dependency makes the build and CI more complex and slower than they really ought to be. I've migrated the Android Support Library annotations to be the Jetbrains equivalents, thus eliminating the Android dependency.

I've verified that in Android Studio and IntelliJ that it highlights a warning when `@Nullable` variable are used unchecked. Also according to their docs, SonarQube will report this too, as per: https://sonarqube.com/coding_rules#rule_key=squid%3AS2637

This reduces Travis-CI build time by 75% (4 mins -> 1 min)