### PR TITLE
Use Callable to allow tryAsOption to support checked Exceptions

### DIFF
--- a/options/core/src/main/java/polanski/option/Option.java
+++ b/options/core/src/main/java/polanski/option/Option.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import polanski.option.function.Action0;
 import polanski.option.function.Action1;
@@ -152,16 +153,16 @@ public abstract class Option<T> {
     }
 
     /**
-     * Option of value returned by the function
+     * Option of value returned by the callable function
      *
-     * @param f     Function that returns a value, that function could throw an exception
+     * @param c     Function that returns a value, that function could throw an exception
      * @param <OUT> Result type
-     * @return Option of a value returned by @f, if @f threw an exception, then returns None
+     * @return Option of a value returned by @c, if @c threw an exception, then returns None
      */
     @NotNull
-    public static <OUT> Option<OUT> tryAsOption(@NotNull final Func0<OUT> f) {
+    public static <OUT> Option<OUT> tryAsOption(@NotNull final Callable<OUT> c) {
         try {
-            return Option.ofObj(f.call());
+            return Option.ofObj(c.call());
         } catch (Exception e) {
             return none();
         }


### PR DESCRIPTION
This is a non-breaking change to the API as `Func0` implements Java 1.5's `Callable`. This allows functions which throw checked Exceptions to be supported.

Some thoughts on alternatives to this: The current master implementation  of `tryAsOption` catches `Exception`, even though the `Func0#call` could only ever throw a `RuntimeException`. An alternative would be to have a new separate method to support the two different behaviors: one which operates only on unchecked exceptions and the other on checked exceptions. Unfortunately they would be required to have different names.

@tomaszpolanski I'm all done with this, so do with it as you like!